### PR TITLE
Remove examples ids

### DIFF
--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -24,8 +24,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 21
-        versionCode 12
-        versionName "1.7.2"
+        versionCode 13
+        versionName "1.7.3"
     }
 
 /*
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.2@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.3@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'http://download.crashlytics.com/maven' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.+'
     }
 }
@@ -18,14 +18,14 @@ repositories {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
-        versionCode 13
-        versionName "1.7.3"
+        targetSdkVersion 22
+        versionCode 14
+        versionName "1.7.4"
     }
 
 /*
@@ -50,8 +50,8 @@ android {
 
 
 dependencies {
-    compile 'com.android.support:gridlayout-v7:20.0.0'
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:gridlayout-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.0'
     compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar'){
         transitive=true
     }

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -24,8 +24,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 21
-        versionCode 10
-        versionName "1.7"
+        versionCode 11
+        versionName "1.7.1"
     }
 
 /*

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.0@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.1@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.3@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -24,8 +24,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 21
-        versionCode 11
-        versionName "1.7.1"
+        versionCode 12
+        versionName "1.7.2"
     }
 
 /*

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -24,8 +24,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 21
-        versionCode 9
-        versionName "1.6"
+        versionCode 10
+        versionName "1.7"
     }
 
 /*
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.6.0@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.0@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -24,8 +24,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 21
-        versionCode 8
-        versionName "1.5.1"
+        versionCode 9
+        versionName "1.6"
     }
 
 /*
@@ -52,10 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.5.1@aar'){
-        transitive=true
-    }
-    compile ('com.cocoahero.android:geojson:1.0.0@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.6.0@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/build.gradle
+++ b/MapBoxAndroidDemo/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'http://download.crashlytics.com/maven' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.0'
         classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.+'
     }
 }
@@ -52,7 +52,7 @@ android {
 dependencies {
     compile 'com.android.support:gridlayout-v7:20.0.0'
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.1@aar'){
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.2@aar'){
         transitive=true
     }
     compile 'com.crashlytics.android:crashlytics:1.+'

--- a/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -54,7 +54,7 @@ public class MainActivity extends ActionBarActivity {
         mv.addMarker(m);
 
         m = new Marker(mv, "Stockholm", "Sweden", new LatLng(59.32995, 18.06461));
-        m.setIcon(new Icon(this, Icon.Size.MEDIUM, "city", "FFFF00"));
+        m.setIcon(new Icon(this, Icon.Size.MEDIUM, "city", "3887be"));
         mv.addMarker(m);
 
         m = new Marker(mv, "Prague", "Czech Republic", new LatLng(50.08734, 14.42112));
@@ -66,6 +66,22 @@ public class MainActivity extends ActionBarActivity {
         mv.addMarker(m);
 
         m = new Marker(mv, "Athens", "Greece", new LatLng(37.97885, 23.71399));
+        mv.addMarker(m);
+
+        m = new Marker(mv, "Tokyo", "Japan", new LatLng(35.70247, 139.71588));
+        m.setIcon(new Icon(this, Icon.Size.LARGE, "city", "3887be"));
+        mv.addMarker(m);
+
+        m = new Marker(mv, "Ayacucho", "Peru", new LatLng(-13.16658, -74.21608));
+        m.setIcon(new Icon(this, Icon.Size.LARGE, "city", "3887be"));
+        mv.addMarker(m);
+
+        m = new Marker(mv, "Nairobi", "Kenya", new LatLng(-1.26676, 36.83372));
+        m.setIcon(new Icon(this, Icon.Size.LARGE, "city", "3887be"));
+        mv.addMarker(m);
+
+        m = new Marker(mv, "Canberra", "Australia", new LatLng(-35.30952, 149.12430));
+        m.setIcon(new Icon(this, Icon.Size.LARGE, "city", "3887be"));
         mv.addMarker(m);
 
         mv.setOnTilesLoadedListener(new TilesLoadedListener() {

--- a/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -50,19 +50,15 @@ public class MainActivity extends ActionBarActivity {
 		mv.loadFromGeoJSONURL("https://gist.githubusercontent.com/tmcw/10307131/raw/21c0a20312a2833afeee3b46028c3ed0e9756d4c/map.geojson");
 //        setButtonListeners();
         Marker m = new Marker(mv, "Edinburgh", "Scotland", new LatLng(55.94629, -3.20777));
-        m.setIcon(new Icon(this, Icon.Size.SMALL, "marker-stroked", "FF0000"));
+        m.setIcon(new Icon(this, Icon.Size.SMALL, "marker-stroked", "ee8a65"));
         mv.addMarker(m);
 
         m = new Marker(mv, "Stockholm", "Sweden", new LatLng(59.32995, 18.06461));
-        m.setIcon(new Icon(this, Icon.Size.MEDIUM, "city", "3887be"));
+        m.setIcon(new Icon(this, Icon.Size.LARGE, "city", "3887be"));
         mv.addMarker(m);
 
         m = new Marker(mv, "Prague", "Czech Republic", new LatLng(50.08734, 14.42112));
-        m.setIcon(new Icon(this, Icon.Size.LARGE, "land-use", "00FFFF"));
-        mv.addMarker(m);
-
-        m = new Marker(mv, "Prague2", "Czech Republic", new LatLng(50.0875, 14.42112));
-        m.setIcon(new Icon(getBaseContext(), Icon.Size.LARGE, "land-use", "00FF00"));
+        m.setIcon(new Icon(this, Icon.Size.MEDIUM, "land-use", "3bb2d0"));
         mv.addMarker(m);
 
         m = new Marker(mv, "Athens", "Greece", new LatLng(37.97885, 23.71399));

--- a/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapBoxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -17,7 +17,6 @@ import com.crashlytics.android.Crashlytics;
 import com.mapbox.mapboxsdk.api.ILatLng;
 import com.mapbox.mapboxsdk.geometry.BoundingBox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.overlay.GpsLocationProvider;
 import com.mapbox.mapboxsdk.overlay.Icon;
 import com.mapbox.mapboxsdk.overlay.Marker;
 import com.mapbox.mapboxsdk.overlay.UserLocationOverlay;
@@ -45,10 +44,8 @@ public class MainActivity extends ActionBarActivity {
 		mv.setZoom(0);
 		currentMap = getString(R.string.streetMapId);
 
-		// Adds an icon that shows location
-		myLocationOverlay = new UserLocationOverlay(new GpsLocationProvider(this), mv);
-		myLocationOverlay.setDrawAccuracyEnabled(true);
-		mv.getOverlays().add(myLocationOverlay);
+		// Show user location (purposely not in follow mode)
+        mv.setUserLocationEnabled(true);
 
 		mv.loadFromGeoJSONURL("https://gist.githubusercontent.com/tmcw/10307131/raw/21c0a20312a2833afeee3b46028c3ed0e9756d4c/map.geojson");
 //        setButtonListeners();
@@ -94,20 +91,6 @@ public class MainActivity extends ActionBarActivity {
 				startActivity(i);
 			}
 		});
-	}
-
-	@Override
-	protected void onResume()
-	{
-		super.onResume();
-		myLocationOverlay.enableMyLocation();
-	}
-
-	@Override
-	protected void onPause()
-	{
-		super.onPause();
-		myLocationOverlay.disableMyLocation();
 	}
 
 	@Override

--- a/MapBoxAndroidDemo/src/main/res/layout/activity_main.xml
+++ b/MapBoxAndroidDemo/src/main/res/layout/activity_main.xml
@@ -9,7 +9,8 @@
             android:id="@+id/mapview"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-			mapbox:mapid="@string/streetMapId"/>
+			mapbox:mapid="@string/streetMapId"
+            mapbox:accessToken="@string/testAccessToken"/>
 
     <ImageView android:layout_width="100dp"
 			   android:layout_height="65dp"

--- a/MapBoxAndroidDemo/src/main/res/values-ja/strings.xml
+++ b/MapBoxAndroidDemo/src/main/res/values-ja/strings.xml
@@ -9,7 +9,7 @@
     <string name="terrain">地形</string>
     <string name="street">ストリート</string>
     <string name="outdoors">アウトドア</string>
-    <string name="woodcut">版画風</string>
+    <string name="woodcut">木版画</string>
     <string name="pencil">鉛筆タッチ</string>
     <string name="spaceShip">宇宙船</string>
 

--- a/MapBoxAndroidDemo/src/main/res/values-ja/strings.xml
+++ b/MapBoxAndroidDemo/src/main/res/values-ja/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="menu_examplemaps">マップ一覧</string>
+    <string name="reportBugs">バグを報告</string>
+
+    <!-- Map Labels -->
+    <string name="satellite">航空写真</string>
+    <string name="terrain">地形</string>
+    <string name="street">ストリート</string>
+    <string name="outdoors">アウトドア</string>
+    <string name="woodcut">版画風</string>
+    <string name="pencil">鉛筆タッチ</string>
+    <string name="spaceShip">宇宙船</string>
+
+</resources>

--- a/MapBoxAndroidDemo/src/main/res/values/strings.xml
+++ b/MapBoxAndroidDemo/src/main/res/values/strings.xml
@@ -24,4 +24,7 @@
 	<string name="pencilMapId">examples.a4c252ab</string>
 	<string name="spaceShipMapId">examples.3hqcl3di</string>
 
+    <!-- Access Token -->
+    <string name="testAccessToken">pk.eyJ1IjoiYmxlZWdlIiwiYSI6IkRGLTFPU00ifQ.qJpq3jytAL9A-z_tkNypqg</string>
+
 </resources>

--- a/MapBoxAndroidDemo/src/main/res/values/strings.xml
+++ b/MapBoxAndroidDemo/src/main/res/values/strings.xml
@@ -16,12 +16,12 @@
 	<string name="spaceShip">Space Ship</string>
 
 	<!-- Map Ids -->
-	<string name="satelliteMapId">brunosan.map-cyglrrfu</string>
-	<string name="terrainMapId">examples.map-zgrqqx0w</string>
-	<string name="streetMapId">examples.map-i87786ca</string>
-	<string name="outdoorsMapId">examples.ik7djhcc</string>
+	<string name="satelliteMapId">mapbox.satellite</string>
+	<string name="terrainMapId">mapbox.run-bike-hike</string>
+	<string name="streetMapId">mapbox.streets</string>
+	<string name="outdoorsMapId">mapbox.outdoors</string>
 	<string name="woodcutMapId">examples.xqwfusor</string>
-	<string name="pencilMapId">examples.a4c252ab</string>
+	<string name="pencilMapId">mapbox.pencil</string>
 	<string name="spaceShipMapId">examples.3hqcl3di</string>
 
     <!-- Access Token -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MapBoxAndroidDemo
+# MapboxAndroidDemo
 
 This is a public demo of the Mapbox Android SDK that's [available now in the Google Play Store](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo).
 We use this to test out changes and collect user feedback and bug reports.


### PR DESCRIPTION
Except for woodcut and spaceship, which don't currently have `mapbox` IDs. Note that when we delete the `examples` account, these styles won't be accessible anymore. cc @bleege 
